### PR TITLE
Creates a module to handle policy document overrides and template vars

### DIFF
--- a/modules/policy_documents/README.md
+++ b/modules/policy_documents/README.md
@@ -1,0 +1,19 @@
+# terraform-aws-tardigrade-iam-principals//modules/policy_documents
+
+Terraform module to merge policy document templates and apply template variables.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| create\_policy\_documents | Controls whether to process IAM policy documents | bool | `"true"` | no |
+| policies | Schema list of policy objects, consisting of `name`, and `template` policy filename (relative to `template_paths`) | object | `<list>` | no |
+| template\_paths | Paths to the directories containing the IAM policy templates | list(string) | n/a | yes |
+| template\_vars | Map of template input variables for IAM policy templates | map(string) | `<map>` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| policies | Returns a map of processed IAM policies |
+

--- a/modules/policy_documents/_docs/MAIN.md
+++ b/modules/policy_documents/_docs/MAIN.md
@@ -1,0 +1,3 @@
+# terraform-aws-tardigrade-iam-principals//modules/policy_documents
+
+Terraform module to merge policy document templates and apply template variables.

--- a/modules/policy_documents/main.tf
+++ b/modules/policy_documents/main.tf
@@ -1,0 +1,21 @@
+locals {
+  handler_vars = {
+    template_paths = join(",", var.template_paths)
+  }
+
+  policies_map = { for item in var.policies : item.name => item }
+}
+
+data "external" "this" {
+  for_each = var.create_policy_documents ? local.policies_map : {}
+
+  program = ["python", "${path.module}/policy_document_handler.py", "-"]
+  query   = merge(local.handler_vars, each.value)
+}
+
+data "template_file" "this" {
+  for_each = var.create_policy_documents ? local.policies_map : {}
+
+  template = data.external.this[each.key].result["policy"]
+  vars     = var.template_vars
+}

--- a/modules/policy_documents/outputs.tf
+++ b/modules/policy_documents/outputs.tf
@@ -1,0 +1,4 @@
+output "policies" {
+  description = "Returns a map of processed IAM policies"
+  value       = { for policy, item in data.external.this : policy => data.template_file.this[policy].rendered }
+}

--- a/modules/policy_documents/variables.tf
+++ b/modules/policy_documents/variables.tf
@@ -1,0 +1,25 @@
+variable "create_policy_documents" {
+  description = "Controls whether to process IAM policy documents"
+  type        = bool
+  default     = true
+}
+
+variable "policies" {
+  description = "Schema list of policy objects, consisting of `name`, and `template` policy filename (relative to `template_paths`)"
+  type = list(object({
+    name     = string
+    template = string
+  }))
+  default = []
+}
+
+variable "template_paths" {
+  description = "Paths to the directories containing the IAM policy templates"
+  type        = list(string)
+}
+
+variable "template_vars" {
+  description = "Map of template input variables for IAM policy templates"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/roles/variables.tf
+++ b/modules/roles/variables.tf
@@ -44,4 +44,3 @@ variable "template_paths" {
   description = "Paths to the directories containing the templates for IAM policies and trusts"
   type        = list(string)
 }
-

--- a/tests/process_policy_documents/main.tf
+++ b/tests/process_policy_documents/main.tf
@@ -1,0 +1,45 @@
+provider aws {
+  region = "us-east-1"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+data "terraform_remote_state" "prereq" {
+  backend = "local"
+  config = {
+    path = "prereq/terraform.tfstate"
+  }
+}
+
+module "policy_documents" {
+  source = "../../modules/policy_documents/"
+  providers = {
+    aws = aws
+  }
+
+  template_paths = ["${path.module}/../templates/"]
+  template_vars = {
+    "account_id" = data.aws_caller_identity.current.account_id
+    "partition"  = data.aws_partition.current.partition
+    "region"     = data.aws_region.current.name
+  }
+
+  policies = [
+    {
+      name     = "tardigrade-alpha-${data.terraform_remote_state.prereq.outputs.random_string.result}"
+      template = "policies/template.json"
+    },
+    {
+      name     = "tardigrade-beta-${data.terraform_remote_state.prereq.outputs.random_string.result}"
+      template = "policies/template.json"
+    },
+  ]
+}
+
+output "policies" {
+  value = module.policy_documents
+}

--- a/tests/process_policy_documents/prereq/main.tf
+++ b/tests/process_policy_documents/prereq/main.tf
@@ -1,0 +1,10 @@
+resource "random_string" "this" {
+  length  = 6
+  upper   = false
+  special = false
+  number  = false
+}
+
+output "random_string" {
+  value = random_string.this
+}

--- a/tests/templates/policies/template.json
+++ b/tests/templates/policies/template.json
@@ -7,6 +7,14 @@
             "Effect": "Allow",
             "Resource": "*",
             "Sid": "PolicyBase"
+        },
+        {
+            "Action": [
+                "ec2:GetConsoleScreenShot"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:${partition}:ec2:${region}:${account_id}:instance/*",
+            "Sid": "TemplateVars"
         }
     ],
     "Version": "2012-10-17"


### PR DESCRIPTION
Step 1 of refactoring this module... Split out the handling of policy document overrides/templating.

Test output:

```
data.terraform_remote_state.prereq: Refreshing state...
module.policy_document.data.external.this["tardigrade-beta-wmnddn"]: Refreshing state...
module.policy_document.data.external.this["tardigrade-alpha-wmnddn"]: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.current: Refreshing state...
module.policy_document.data.template_file.this["tardigrade-beta-wmnddn"]: Refreshing state...
module.policy_document.data.template_file.this["tardigrade-alpha-wmnddn"]: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

policies = {
  "policies" = {
    "tardigrade-alpha-wmnddn" = "{\"Statement\": [{\"Action\": [\"sts:GetCallerIdentity\"], \"Effect\": \"Allow\", \"Resource\": \"*\", \"Sid\": \"PolicyBase\"}, {\"Action\": [\"ec2:GetConsoleScreenShot\"], \"Effect\": \"Allow\", \"Resource\": \"arn:aws:ec2:us-east-1:<account_id>:instance/*\", \"Sid\": \"TemplateVars\"}], \"Version\": \"2012-10-17\"}"
    "tardigrade-beta-wmnddn" = "{\"Statement\": [{\"Action\": [\"sts:GetCallerIdentity\"], \"Effect\": \"Allow\", \"Resource\": \"*\", \"Sid\": \"PolicyBase\"}, {\"Action\": [\"ec2:GetConsoleScreenShot\"], \"Effect\": \"Allow\", \"Resource\": \"arn:aws:ec2:us-east-1:<account_id>:instance/*\", \"Sid\": \"TemplateVars\"}], \"Version\": \"2012-10-17\"}"
  }
}
```