### PR TITLE
Updates module to make dependency on policy_arns more explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 4.0.0
+
+**Released**: Not yet released
+
+**Commit Delta**: [Change from 3.1.0 release](https://github.com/plus3it/terraform-aws-tardigrade-iam-principals/compare/3.1.0...4.0.0)
+
+**Summary**:
+
+*   **WARNING**: This release renames the `dependencies` variable to `policy_arns`,
+    as policy attachments are the only resource in the module that can cause race
+    conditions requiring explicit dependency management.
+*   The `policy_arns` variable improves dependency handling during replacing updates
+    of policies, as it is used directly (and only) as an attribute in the role/user
+    policy attachment. Because it is not used in the `for_each` expressions, users
+    can pass the output of another resource to `policy_arns`. Being used as an attribute
+    is how Terraform establishes the tree for dependency ordering. See [PR #38](https://github.com/plus3it/terraform-aws-tardigrade-iam-principals/pull/38).
+
+*   Adds support for managing IAM user access keys
+
+### 3.1.0
+
+**Released**: 2019.12.16
+
+**Commit Delta**: [Change from 3.0.0 release](https://github.com/plus3it/terraform-aws-tardigrade-iam-principals/compare/3.0.0...3.1.0)
+
+**Summary**:
+
+*   Adds support for managing IAM user access keys
+
 ### 3.0.0
 
 **Released**: 2019.11.5

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Terraform module to create IAM managed policies, roles, and users
 | create\_policies | Controls whether to create IAM policies | bool | `"true"` | no |
 | create\_roles | Controls whether to create IAM roles | bool | `"true"` | no |
 | create\_users | Controls whether an IAM user will be created | bool | `"true"` | no |
-| dependencies | List of dependency resources applied to `depends\_on` in every resource in this module. Typically used with IAM managed policy ARNs that are managed in the same Terraform config | list(string) | `<list>` | no |
 | description | Description of the roles. May also be set per-role in the role-schema | string | `"null"` | no |
 | force\_destroy | When destroying these users, destroy even if they have non-Terraform-managed IAM access keys, login profile or MFA devices. Without force\_destroy a user with non-Terraform-managed access keys and login profile will fail to be destroyed. May also be set per-user in the user-schema | bool | `"true"` | no |
 | force\_detach\_policies | Force detaches any policies the roles have before destroying them. May also be set per-role in the role-schema | bool | `"true"` | no |
@@ -17,6 +16,7 @@ Terraform module to create IAM managed policies, roles, and users
 | path | The path to the role. See \[IAM Identifiers\]\(https://docs.aws.amazon.com/IAM/latest/UserGuide/reference\_identifiers.html\) for more information. May also be set per-role in the role-schema | string | `"null"` | no |
 | permissions\_boundary | ARN of the policy that is used to set the permissions boundary for the roles. May also be set per-role in the role-schema | string | `"null"` | no |
 | policies | Schema list of policy objects, consisting of `name`, `template` policy filename \(relative to `template\_paths`\), \(OPTIONAL\) `description`, \(OPTIONAL\) `path` | object | `<list>` | no |
+| policy\_arns | List of all managed policy ARNs used in the roles and users objects. This is needed to properly order policy attachments/detachments on resource cycles | list(string) | `<list>` | no |
 | roles | Schema list of IAM roles, consisting of `name`, `assume\_role\_policy`, `policy\_arns` list \(OPTIONAL\), `inline\_policies` schema list \(OPTIONAL\), `description` \(OPTIONAL\), `force\_detach\_polices` \(OPTIONAL\), `max\_session\_duration` \(OPTIONAL\), `path` \(OPTIONAL\), `permissions\_boundary` \(OPTIONAL\), `tags` \(OPTIONAL\) | object | `<list>` | no |
 | tags | Map of tags to apply to the IAM roles. May also be set per-role in the role-schema | map(string) | `<map>` | no |
 | template\_paths | Paths to the directories containing the IAM policy templates | list(string) | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,10 @@ module "policies" {
 module "roles" {
   source = "./modules/roles/"
 
-  dependencies = [for policy in module.policies.policies : policy.arn]
+  policy_arns = distinct(concat(
+    var.policy_arns,
+    [for policy in module.policies.policies : policy.arn]
+  ))
 
   create_roles   = var.create_roles
   template_paths = var.template_paths
@@ -34,7 +37,10 @@ module "roles" {
 module "users" {
   source = "./modules/users/"
 
-  dependencies = [for policy in module.policies.policies : policy.arn]
+  policy_arns = distinct(concat(
+    var.policy_arns,
+    [for policy in module.policies.policies : policy.arn]
+  ))
 
   create_users   = var.create_users
   template_paths = var.template_paths

--- a/modules/roles/README.md
+++ b/modules/roles/README.md
@@ -7,12 +7,12 @@ Terraform module to create IAM roles
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | create\_roles | Controls whether to create IAM roles | bool | `"true"` | no |
-| dependencies | List of dependency resources applied to `depends\_on` in every resource in this module. Typically used with IAM managed policy ARNs that are managed in the same Terraform config | list(string) | `<list>` | no |
 | description | Description of the roles. May also be set per-role in the role-schema | string | `"null"` | no |
 | force\_detach\_policies | Force detaches any policies the roles have before destroying them. May also be set per-role in the role-schema | bool | `"true"` | no |
 | max\_session\_duration | The maximum session duration \(in seconds\) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours. May also be set per-role in the role-schema | number | `"null"` | no |
 | path | The path to the role. See \[IAM Identifiers\]\(https://docs.aws.amazon.com/IAM/latest/UserGuide/reference\_identifiers.html\) for more information. May also be set per-role in the role-schema | string | `"null"` | no |
 | permissions\_boundary | ARN of the policy that is used to set the permissions boundary for the roles. May also be set per-role in the role-schema | string | `"null"` | no |
+| policy\_arns | List of all managed policy ARNs used in the roles object. This is needed to properly order policy attachments/detachments on resource cycles | list(string) | `<list>` | no |
 | roles | Schema list of IAM roles, consisting of `name`, `assume\_role\_policy`, `policy\_arns` list \(OPTIONAL\), `inline\_policies` schema list \(OPTIONAL\), `description` \(OPTIONAL\), `force\_detach\_policies` \(OPTIONAL\), `max\_session\_duration` \(OPTIONAL\), `path` \(OPTIONAL\), `permissions\_boundary` \(OPTIONAL\), `tags` \(OPTIONAL\) | object | `<list>` | no |
 | tags | Map of tags to apply to the IAM roles. May also be set per-role in the role-schema | map(string) | `<map>` | no |
 | template\_paths | Paths to the directories containing the IAM policy templates | list(string) | n/a | yes |

--- a/modules/roles/variables.tf
+++ b/modules/roles/variables.tf
@@ -4,12 +4,6 @@ variable "create_roles" {
   default     = true
 }
 
-variable "dependencies" {
-  description = "List of dependency resources applied to `depends_on` in every resource in this module. Typically used with IAM managed policy ARNs that are managed in the same Terraform config"
-  type        = list(string)
-  default     = []
-}
-
 variable "description" {
   description = "Description of the roles. May also be set per-role in the role-schema"
   type        = string
@@ -38,6 +32,12 @@ variable "permissions_boundary" {
   description = "ARN of the policy that is used to set the permissions boundary for the roles. May also be set per-role in the role-schema"
   type        = string
   default     = null
+}
+
+variable "policy_arns" {
+  description = "List of all managed policy ARNs used in the roles object. This is needed to properly order policy attachments/detachments on resource cycles"
+  type        = list(string)
+  default     = []
 }
 
 variable "roles" {

--- a/modules/users/README.md
+++ b/modules/users/README.md
@@ -7,10 +7,10 @@ Terraform module to create IAM users
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | create\_users | Controls whether an IAM user will be created | bool | `"true"` | no |
-| dependencies | List of dependency resources applied to `depends\_on` in every resource in this module. Typically used with IAM managed policy ARNs that are managed in the same Terraform config | list(string) | `<list>` | no |
 | force\_destroy | When destroying these users, destroy even if they have non-Terraform-managed IAM access keys, login profile or MFA devices. Without force\_destroy a user with non-Terraform-managed access keys and login profile will fail to be destroyed. May also be set per-user in the user-schema | bool | `"true"` | no |
 | path | The path to the user. See \[IAM Identifiers\]\(https://docs.aws.amazon.com/IAM/latest/UserGuide/reference\_identifiers.html\) for more information. May also be set per-user in the user-schema | string | `"null"` | no |
 | permissions\_boundary | ARN of the policy that is used to set the permissions boundary for the users. May also be set per-user in the user-schema | string | `"null"` | no |
+| policy\_arns | List of all managed policy ARNs used in the users object. This is needed to properly order policy attachments/detachments on resource cycles | list(string) | `<list>` | no |
 | tags | Map of tags to apply to the IAM roles | map(string) | `<map>` | no |
 | template\_paths | Paths to the directories containing the templates for IAM policies and trusts | list(string) | n/a | yes |
 | template\_vars | Map of input variables for IAM trust and policy templates | map(string) | `<map>` | no |

--- a/modules/users/variables.tf
+++ b/modules/users/variables.tf
@@ -4,12 +4,6 @@ variable "create_users" {
   default     = true
 }
 
-variable "dependencies" {
-  description = "List of dependency resources applied to `depends_on` in every resource in this module. Typically used with IAM managed policy ARNs that are managed in the same Terraform config"
-  type        = list(string)
-  default     = []
-}
-
 variable "force_destroy" {
   description = "When destroying these users, destroy even if they have non-Terraform-managed IAM access keys, login profile or MFA devices. Without force_destroy a user with non-Terraform-managed access keys and login profile will fail to be destroyed. May also be set per-user in the user-schema"
   type        = bool
@@ -26,6 +20,12 @@ variable "permissions_boundary" {
   description = "ARN of the policy that is used to set the permissions boundary for the users. May also be set per-user in the user-schema"
   type        = string
   default     = null
+}
+
+variable "policy_arns" {
+  description = "List of all managed policy ARNs used in the users object. This is needed to properly order policy attachments/detachments on resource cycles"
+  type        = list(string)
+  default     = []
 }
 
 variable "template_paths" {

--- a/tests/create_all/main.tf
+++ b/tests/create_all/main.tf
@@ -97,7 +97,6 @@ locals {
       force_detach_policies = false
       max_session_duration  = 3600
       path                  = "/tardigrade/alpha/"
-      permissions_boundary  = "${local.policy_arn_base}/tardigrade/tardigrade-beta-${local.test_id}"
       tags = {
         Env = "tardigrade"
       }
@@ -122,13 +121,12 @@ locals {
 
   users = [
     {
-      name                 = "tardigrade-user-alpha-${local.test_id}"
-      policy_arns          = local.policy_arns
-      inline_policies      = local.inline_policies
-      access_keys           = [for access_key in local.access_keys : merge(local.access_key_base, access_key)]
-      force_destroy        = false
-      path                 = "/tardigrade/alpha/"
-      permissions_boundary = "${local.policy_arn_base}/tardigrade/tardigrade-beta-${local.test_id}"
+      name            = "tardigrade-user-alpha-${local.test_id}"
+      policy_arns     = local.policy_arns
+      inline_policies = local.inline_policies
+      access_keys     = [for access_key in local.access_keys : merge(local.access_key_base, access_key)]
+      force_destroy   = false
+      path            = "/tardigrade/alpha/"
       tags = {
         Env = "tardigrade"
       }
@@ -171,7 +169,6 @@ module "create_all" {
   force_destroy         = true
   max_session_duration  = 7200
   path                  = "/tardigrade/"
-  permissions_boundary  = "${local.policy_arn_base}/tardigrade-alpha-${local.test_id}"
   tags = {
     Test = "true"
   }

--- a/tests/create_roles/main.tf
+++ b/tests/create_roles/main.tf
@@ -82,6 +82,8 @@ module "create_roles" {
     aws = aws
   }
 
+  policy_arns = local.policy_arns
+
   template_paths = ["${path.module}/../templates/"]
   template_vars = {
     "account_id" = data.aws_caller_identity.current.account_id

--- a/tests/create_users/main.tf
+++ b/tests/create_users/main.tf
@@ -93,6 +93,8 @@ module "create_users" {
     aws = aws
   }
 
+  policy_arns = local.policy_arns
+
   template_paths = ["${path.module}/../templates/"]
   template_vars = {
     "account_id" = data.aws_caller_identity.current.account_id

--- a/tests/create_users_policies/main.tf
+++ b/tests/create_users_policies/main.tf
@@ -51,8 +51,9 @@ locals {
 
   policies = [
     {
-      name     = "tardigrade-alpha-${local.test_id}"
-      template = "policies/template.json"
+      description = "test"
+      name        = "tardigrade-alpha-${local.test_id}"
+      template    = "policies/template.json"
     },
     {
       name     = "tardigrade-beta-${local.test_id}"
@@ -63,12 +64,11 @@ locals {
 
   users = [
     {
-      name                 = "tardigrade-user-alpha-${local.test_id}"
-      policy_arns          = local.policy_arns
-      inline_policies      = local.inline_policies
-      force_destroy        = false
-      path                 = "/tardigrade/alpha/"
-      permissions_boundary = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:policy/tardigrade/tardigrade-beta-${local.test_id}"
+      name            = "tardigrade-user-alpha-${local.test_id}"
+      policy_arns     = local.policy_arns
+      inline_policies = local.inline_policies
+      force_destroy   = false
+      path            = "/tardigrade/alpha/"
       tags = {
         Env = "tardigrade"
       }
@@ -116,7 +116,7 @@ module "create_users" {
 
   # To create the managed policies in the same config, from the `policies` module,
   # need to construct the ARNs manually in `users.policy_arns` and pass the ARN
-  # outputs from the module `policies` as `dependencies`. This is because `users.policy_arns`
+  # outputs from the module `policies` as `policy_arns`. This is because `users.policy_arns`
   # is used in the for_each logic and passing the `policies` module output directly
   # will generate an error:
   #  > The "for_each" value depends on resource attributes that cannot be determined
@@ -124,7 +124,7 @@ module "create_users" {
   #  > To work around this, use the -target argument to first apply only the
   #  > resources that the for_each depends on.
 
-  dependencies = [for policy in module.policies.policies : policy.arn]
+  policy_arns = [for policy in module.policies.policies : policy.arn]
 
   template_paths = ["${path.module}/../templates/"]
   template_vars = {
@@ -135,7 +135,7 @@ module "create_users" {
 
   force_destroy        = true
   path                 = "/tardigrade/"
-  permissions_boundary = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:policy/tardigrade-alpha-${local.test_id}"
+  permissions_boundary = module.policies.policies["tardigrade-alpha-${local.test_id}"].arn
   tags = {
     Test = "true"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -16,12 +16,6 @@ variable "create_users" {
   default     = true
 }
 
-variable "dependencies" {
-  description = "List of dependency resources applied to `depends_on` in every resource in this module. Typically used with IAM managed policy ARNs that are managed in the same Terraform config"
-  type        = list(string)
-  default     = []
-}
-
 variable "description" {
   description = "Description of the roles. May also be set per-role in the role-schema"
   type        = string
@@ -56,6 +50,12 @@ variable "permissions_boundary" {
   description = "ARN of the policy that is used to set the permissions boundary for the roles. May also be set per-role in the role-schema"
   type        = string
   default     = null
+}
+
+variable "policy_arns" {
+  description = "List of all managed policy ARNs used in the roles and users objects. This is needed to properly order policy attachments/detachments on resource cycles"
+  type        = list(string)
+  default     = []
 }
 
 variable "policies" {


### PR DESCRIPTION
In the prior approach, `depends_on` is not evaluated when the policy is updated in a way that requires a resource cycle (destroy/create), such as when modifying the policy name or description. That means terraform would try to destroy the policy and fail, because the policy would be attached to a role/user/permissions_boundary.

The new approach here reworks the dependencies inputs as `policy_arns` since this is really the only resource that should have these dependencies. The `policy_arns` variable is used _only_ as an attribute on the policy attachment. Importantly, it _is not_ used in the `for_each` evaluation. This means the user can resolve the `policy_arns` from the outputs of another resource. Because these `policy_arns` values are then used in the role/user policy attachment, terraform can properly determine the order of operations.

However, as before, note that it is still important within the `roles.policy_arns` and `users.policy_arns` objects that the values _are not_ dependent on the outputs of another resource, as those objects are used in the `for_each` expressions.
