### PR TITLE
Reverses instance_profile logic so any value not `true` will negate the resource

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.2
+current_version = 4.0.3
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/modules/roles/main.tf
+++ b/modules/roles/main.tf
@@ -82,7 +82,7 @@ resource "aws_iam_role_policy" "this" {
 
 # attach an instance profile to the IAM roles
 resource "aws_iam_instance_profile" "this" {
-  for_each = { for name, role in local.roles_map : name => role if var.create_roles && lookup(role, "instance_profile", false) != false }
+  for_each = { for name, role in local.roles_map : name => role if var.create_roles && lookup(role, "instance_profile", null) == true }
 
   name = aws_iam_role.this[each.key].id
   role = aws_iam_role.this[each.key].id


### PR DESCRIPTION
Previously, instance_profile had to be set to `false` to properly negate the resource. E.g. Counter-intuitively, values of `null` would still trigger the resource...