### PR TITLE
Loops over same object as used for the lookup

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.3
+current_version = 4.0.4
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/modules/policy_documents/outputs.tf
+++ b/modules/policy_documents/outputs.tf
@@ -1,4 +1,4 @@
 output "policies" {
   description = "Returns a map of processed IAM policies"
-  value       = { for policy, item in data.external.this : policy => data.template_file.this[policy].rendered }
+  value       = { for policy, item in data.template_file.this : policy => item.rendered }
 }


### PR DESCRIPTION
This helps avoid lookup reference errors, since if data.template_file.this is empty no lookup will be performed.