### PR TITLE
Marks users output sensitive as it may contain access_keys

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 10.0.0
+current_version = 10.0.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,4 +16,5 @@ output "roles" {
 output "users" {
   description = "IAM user resources"
   value       = module.users
+  sensitive   = true
 }

--- a/tests/create_all/main.tf
+++ b/tests/create_all/main.tf
@@ -325,5 +325,6 @@ data "terraform_remote_state" "prereq" {
 }
 
 output "create_all" {
-  value = module.create_all
+  value     = module.create_all
+  sensitive = true
 }


### PR DESCRIPTION
Results of `make test`:
```
PASS
ok      tardigarde-ci/tests     400.386s
[terratest/test]: Completed successfully!
```